### PR TITLE
Fix new bug that causes Face Alignment constructor to fail

### DIFF
--- a/datasets/generate_dataset.py
+++ b/datasets/generate_dataset.py
@@ -23,7 +23,7 @@ class GeneratorDataset(Dataset, ABC):
 
         self.initialize()
         self.face_detector_mediapipe = FaceDetector('google')
-        self.face_detector = face_alignment.FaceAlignment(face_alignment.LandmarksType._2D, device=self.device)
+        self.face_detector = face_alignment.FaceAlignment(face_alignment.LandmarksType.TWO_D, device=self.device)
 
     def initialize(self):
         path = Path(self.source, 'source')


### PR DESCRIPTION
The constructor face_alignment.FaceAlignment fails, citing `AttributeError: _2D`. Based on an online GitHub thread that I found, there was a model change in the face-alignment package that causes this. This commit resolves this issue. This bug fix was tested on the default face-alignment pip package version face-alignment==1.3.5. The link to the GitHub thread is below:

https://github.com/OpenTalker/video-retalking/issues/48#issuecomment-1583962108